### PR TITLE
Use valid category in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -4,6 +4,6 @@ author=Vittorio Colzani <vittorio@vittorio.no.it>
 maintainer=Vittorio Colzani <vittorio@vittorio.no.it>Rob Tillaart <rob.tillaart@gmail.com>
 sentence=Library PCF9634 library for Arduino. 
 paragraph=Support dimming and blinking
-category=LED controller
+category=Device Control
 url=https://github.com/viktor1970/PCA9634
 architectures=*


### PR DESCRIPTION
The previous `category` value caused the warning:
```
WARNING: Category 'LED controller' in library PCF9634 is not valid. Setting to 'Uncategorized'
```
List of valid category values:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format